### PR TITLE
Document Slack, Teams, and Outlook support across specs

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -1,8 +1,8 @@
 # implementation.md
 
-Product: Thread Condenser  
-Purpose: Convert long Slack threads into auditable briefs of decisions, risks, actions, and open questions with provenance.  
-Stack: Python 3.11, FastAPI, Slack Bolt (FastAPI adapter), Celery, Redis, Postgres + pgvector, httpx, Pydantic, Alembic.
+Product: Thread Condenser
+Purpose: Convert long Slack, Microsoft Teams, and Outlook threads into auditable briefs of decisions, risks, actions, and open questions with provenance.
+Stack: Python 3.11, FastAPI, Slack Bolt (FastAPI adapter), Microsoft Bot Framework + msal + Microsoft Graph, Celery, Redis, Postgres + pgvector, httpx, Pydantic, Alembic.
 
 This is a complete, standalone implementation plan with ready code. Copy files as indicated, set env vars, run Docker Compose, and iterate.
 
@@ -25,11 +25,26 @@ thread-condenser/
     api/
       __init__.py
       v1.py
-    slack/
+    platforms/
       __init__.py
-      bolt_app.py
-      blocks.py
-      publisher.py
+      base.py
+      graph_client.py
+      registry.py
+      slack/
+        __init__.py
+        bolt_app.py
+        blocks.py
+        publisher.py
+      teams/
+        __init__.py
+        bot.py
+        cards.py
+        publisher.py
+      outlook/
+        __init__.py
+        graph.py
+        actionable.py
+        publisher.py
     llm/
       __init__.py
       base.py
@@ -89,6 +104,9 @@ SQLAlchemy==2.0.35
 alembic==1.13.2
 psycopg[binary]==3.2.3
 httpx==0.27.2
+msal==1.28.0
+botbuilder-core==4.15.0
+botframework-connector==4.15.0
 celery==5.4.0
 redis==5.0.8
 python-json-logger==2.0.7
@@ -186,6 +204,15 @@ SLACK_SIGNING_SECRET=***
 SLACK_APP_LEVEL_TOKEN=xapp-***  # optional for Socket Mode, not used here
 PUBLIC_BASE_URL=http://localhost:8080
 
+# Microsoft Graph / Teams / Outlook
+M365_TENANT_ID=***
+M365_CLIENT_ID=***
+M365_CLIENT_SECRET=***
+TEAMS_BOT_APP_ID=***
+TEAMS_BOT_APP_PASSWORD=***
+GRAPH_NOTIFICATION_SECRET=change-me
+OUTLOOK_SHARED_MAILBOXES=support@contoso.com,leadership@contoso.com
+
 # LLM
 LLM_PROVIDER=openai
 OPENAI_API_KEY=sk-***
@@ -269,8 +296,10 @@ class Workspace(Base):
     __tablename__ = "workspaces"
     id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
     tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
-    slack_team_id = Column(String, unique=True, nullable=False)
+    slack_team_id = Column(String, unique=True, nullable=True)
+    m365_tenant_id = Column(String, nullable=True)
     bot_user_id = Column(String, nullable=True)
+    teams_bot_app_id = Column(String, nullable=True)
     settings = Column(JSON, default=dict)
     created_at = Column(DateTime, default=datetime.utcnow)
 
@@ -278,45 +307,62 @@ class Channel(Base):
     __tablename__ = "channels"
     id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
-    slack_channel_id = Column(String, nullable=False)
+    platform = Column(String, nullable=False)  # slack|msteams|outlook
+    external_id = Column(String, nullable=False)
+    parent_resource_id = Column(String, nullable=True)  # team id, chat id, mailbox id
+    display_name = Column(String, nullable=True)
+    mailbox_address = Column(String, nullable=True)
     timezone = Column(String, nullable=True)
     policies = Column(JSON, default=dict)
-    __table_args__ = (UniqueConstraint("workspace_id","slack_channel_id"),)
+    metadata = Column(JSON, default=dict)
+    __table_args__ = (UniqueConstraint("workspace_id","platform","external_id"),)
 
 class User(Base):
     __tablename__ = "users"
     id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
-    slack_user_id = Column(String, nullable=False)
+    platform = Column(String, nullable=False)
+    platform_user_id = Column(String, nullable=False)
     display_name = Column(String, nullable=False)
+    email = Column(String, nullable=True)
     role = Column(String, nullable=True)
     seniority_weight = Column(Float, default=1.0)
-    __table_args__ = (UniqueConstraint("workspace_id","slack_user_id"),)
+    metadata = Column(JSON, default=dict)
+    __table_args__ = (UniqueConstraint("workspace_id","platform","platform_user_id"),)
 
 class Thread(Base):
     __tablename__ = "threads"
     id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
     channel_id = Column(UUID(as_uuid=True), ForeignKey("channels.id"), nullable=False)
-    slack_thread_ts = Column(String, nullable=False)
-    url = Column(String, nullable=False)
+    platform = Column(String, nullable=False)
+    source_thread_id = Column(String, nullable=False)
+    source_parent_id = Column(String, nullable=True)  # Slack channel, Teams chat, Outlook conversationId
+    source_url = Column(String, nullable=False)
     content_hash = Column(String, nullable=True)
+    delta_token = Column(String, nullable=True)
     status = Column(String, default="open")
     created_at = Column(DateTime, default=datetime.utcnow)
-    __table_args__ = (UniqueConstraint("workspace_id","slack_thread_ts"),)
+    __table_args__ = (UniqueConstraint("workspace_id","platform","source_thread_id"),)
 
 class Message(Base):
     __tablename__ = "messages"
     id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
     thread_id = Column(UUID(as_uuid=True), ForeignKey("threads.id"), nullable=False)
-    slack_ts = Column(String, nullable=False)
+    platform = Column(String, nullable=False)
+    source_msg_id = Column(String, nullable=False)
+    parent_msg_id = Column(String, nullable=True)
     author_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     text = Column(Text, nullable=False)
     text_hash = Column(String, nullable=False)
     lang = Column(String, nullable=True)
     reactions_json = Column(JSON, default=dict)
+    metadata_json = Column(JSON, default=dict)
     created_at = Column(DateTime, default=datetime.utcnow)
-    __table_args__ = (UniqueConstraint("thread_id","slack_ts"), Index("ix_msg_thread_ts","thread_id","slack_ts"))
+    __table_args__ = (
+        UniqueConstraint("thread_id","source_msg_id"),
+        Index("ix_msg_thread_source","thread_id","source_msg_id"),
+    )
 
 class Segment(Base):
     __tablename__ = "segments"
@@ -342,6 +388,7 @@ class Item(Base):
     status = Column(String, default="proposed")  # proposed|confirmed|in_progress|done|blocked
     confidence = Column(Float, default=0.0)
     promoted_at = Column(DateTime, nullable=True)
+    source_platform = Column(String, nullable=False)
 
 class Evidence(Base):
     __tablename__ = "evidence"
@@ -356,12 +403,28 @@ class PeopleMap(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
     thread_id = Column(UUID(as_uuid=True), ForeignKey("threads.id"), nullable=False)
     display_name = Column(String, nullable=False)
-    slack_user_id = Column(String, nullable=False)
+    platform = Column(String, nullable=False)
+    native_user_id = Column(String, nullable=True)
+    email = Column(String, nullable=True)
+    metadata = Column(JSON, default=dict)
+
+class GraphSubscription(Base):
+    __tablename__ = "graph_subscriptions"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=ulid)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
+    platform = Column(String, nullable=False)
+    resource = Column(String, nullable=False)
+    notification_url = Column(String, nullable=False)
+    delta_token = Column(String, nullable=True)
+    expires_at = Column(DateTime, nullable=False)
+    metadata = Column(JSON, default=dict)
+    __table_args__ = (UniqueConstraint("workspace_id","platform","resource"),)
 
 class Brief(Base):
     __tablename__ = "briefs"
     run_id = Column(String, primary_key=True)
     thread_id = Column(UUID(as_uuid=True), ForeignKey("threads.id"), nullable=False)
+    platform = Column(String, nullable=False)
     version = Column(String, nullable=False)
     model_version = Column(String, nullable=True)
     api_version = Column(String, nullable=True)
@@ -452,7 +515,7 @@ make migrate
 **app/config.py**
 ```python
 from pydantic_settings import BaseSettings
-from pydantic import AnyUrl
+from pydantic import AnyUrl, Field, field_validator
 
 class Settings(BaseSettings):
     APP_ENV: str = "dev"
@@ -464,6 +527,14 @@ class Settings(BaseSettings):
     SLACK_SIGNING_SECRET: str
     PUBLIC_BASE_URL: str = "http://localhost:8080"
 
+    M365_TENANT_ID: str | None = None
+    M365_CLIENT_ID: str | None = None
+    M365_CLIENT_SECRET: str | None = None
+    TEAMS_BOT_APP_ID: str | None = None
+    TEAMS_BOT_APP_PASSWORD: str | None = None
+    GRAPH_NOTIFICATION_SECRET: str | None = None
+    OUTLOOK_SHARED_MAILBOXES: list[str] = Field(default_factory=list)
+
     LLM_PROVIDER: str = "openai"
     OPENAI_API_KEY: str | None = None
     OPENAI_MODEL: str = "gpt-4o-mini"
@@ -472,6 +543,13 @@ class Settings(BaseSettings):
 
     WATCH_WINDOW_SECONDS: int = 21600
     PROMOTION_THRESHOLD: float = 0.65
+
+    @field_validator("OUTLOOK_SHARED_MAILBOXES", mode="before")
+    @classmethod
+    def _split_mailboxes(cls, value: str | list[str] | None) -> list[str] | None:
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        return value
 
     class Config:
         env_file = ".env"
@@ -501,11 +579,28 @@ def setup_logging():
 **app/schemas.py**
 ```python
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 class SupportRef(BaseModel):
+    platform: str
+    native_id: str
     msg_id: str
     quote: str
+    url: Optional[str] = None
+
+class PersonRef(BaseModel):
+    display_name: str
+    platform: str
+    native_id: Optional[str] = None
+    email: Optional[str] = None
+
+class Provenance(BaseModel):
+    thread_url: str
+    message_ids: List[str]
+    model_version: Optional[str] = None
+    run_id: Optional[str] = None
+    source_platform: str
+    source_thread_ref: Dict[str, str]
 
 class Decision(BaseModel):
     title: str
@@ -539,12 +634,13 @@ class OpenQuestion(BaseModel):
     supporting_msgs: List[SupportRef]
 
 class CondenseResult(BaseModel):
+    platform: str
     decisions: List[Decision]
     risks: List[Risk]
     actions: List[ActionItem]
     open_questions: List[OpenQuestion]
-    people_map: dict
-    provenance: dict
+    people_map: Dict[str, PersonRef]
+    provenance: Provenance
     changelog: List[dict] = []
 ```
 
@@ -585,7 +681,9 @@ def get_db():
 
 ---
 
-## 6) Slack app configuration
+## 6) Channel app configuration
+
+### Slack
 
 Create a Slack app at api.slack.com/apps:
 
@@ -595,67 +693,285 @@ Create a Slack app at api.slack.com/apps:
 - **Event Subscriptions**: Enable events. Request URL `https://<PUBLIC_BASE_URL>/slack/events`. Subscribe to: `message.channels`, `reaction_added`, `link_shared`.
 - Install to workspace. Put **SLACK_BOT_TOKEN** and **SLACK_SIGNING_SECRET** in `.env`.
 
+### Microsoft Teams
+
+1. In Azure Portal, create a Bot Channels Registration (or Azure Bot) with Teams channel enabled.
+2. Configure Messaging endpoint: `https://<PUBLIC_BASE_URL>/teams/messages`.
+3. Create a Teams app manifest with:
+   - Message extension command `condense` that supports `message` context.
+   - Action command pointing to `https://<PUBLIC_BASE_URL>/teams/messages`.
+   - Required resource specific consent scopes `Chat.Read.All`, `ChannelMessage.Read.All`, `ChatMessage.Send`, `TeamsActivity.Send`.
+4. Grant admin consent for Microsoft Graph scopes listed above plus `User.Read.All`.
+5. Store bot credentials in `.env` as **TEAMS_BOT_APP_ID** and **TEAMS_BOT_APP_PASSWORD**.
+6. Configure Microsoft Graph change notifications for Teams channels/chats via `https://<PUBLIC_BASE_URL>/graph/notifications` using **GRAPH_NOTIFICATION_SECRET** as the validation token.
+
+### Outlook actionable messages
+
+1. Register an Azure AD application with Microsoft Graph permissions `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`, `offline_access`, `User.Read.All`.
+2. Grant admin consent and note **M365_CLIENT_ID**, **M365_CLIENT_SECRET**, **M365_TENANT_ID**.
+3. Configure Outlook actionable message provider (https://outlook.office.com/connectors/oam) with the app ID and host domain.
+4. For shared mailboxes that should trigger condensation, list addresses in **OUTLOOK_SHARED_MAILBOXES**.
+5. Set Microsoft Graph change notification endpoint `https://<PUBLIC_BASE_URL>/graph/notifications` for mailbox resources (e.g., `/users/<mailbox>/messages`). Use the same **GRAPH_NOTIFICATION_SECRET**.
+6. Deploy the Outlook add-in manifest pointing the task pane button to `https://<PUBLIC_BASE_URL>/outlook/actions`.
+
 ---
 
-## 7) Slack handlers and UI
+## 7) Channel handlers and UI
 
-**app/slack/bolt_app.py**
+**app/platforms/__init__.py**
 ```python
+"""Namespace package for platform adapters."""
+
+__all__ = []
+```
+
+**app/platforms/base.py**
+```python
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from app.schemas import CondenseResult
+
+
+@dataclass
+class ThreadContext:
+    platform: str
+    workspace_id: str
+    channel_id: str
+    thread_id: str
+    requester_id: Optional[str]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class PlatformAdapter(ABC):
+    platform: str
+
+    @abstractmethod
+    async def acknowledge(self, context: ThreadContext) -> None:
+        ...
+
+    @abstractmethod
+    async def send_processing_notice(self, context: ThreadContext) -> None:
+        ...
+
+    @abstractmethod
+    async def publish_brief(self, context: ThreadContext, brief: CondenseResult) -> None:
+        ...
+
+    @abstractmethod
+    def serialize_thread_ref(self, context: ThreadContext) -> Dict[str, Any]:
+        ...
+
+    @abstractmethod
+    def context_from_thread_ref(self, thread_ref: Dict[str, Any], requester_id: Optional[str]) -> ThreadContext:
+        ...
+```
+
+**app/platforms/graph_client.py**
+```python
+import asyncio
+from typing import Any, Dict, Optional
+
+import httpx
+import msal
+
+from app.config import settings
+
+SCOPES = ["https://graph.microsoft.com/.default"]
+
+
+class GraphClient:
+    def __init__(self) -> None:
+        if not settings.M365_CLIENT_ID or not settings.M365_CLIENT_SECRET or not settings.M365_TENANT_ID:
+            raise RuntimeError("Microsoft Graph credentials are not configured")
+        self._app = msal.ConfidentialClientApplication(
+            client_id=settings.M365_CLIENT_ID,
+            authority=f"https://login.microsoftonline.com/{settings.M365_TENANT_ID}",
+            client_credential=settings.M365_CLIENT_SECRET,
+        )
+
+    async def _acquire_token(self) -> str:
+        def acquire() -> str:
+            result = self._app.acquire_token_silent(SCOPES, account=None)
+            if not result:
+                result = self._app.acquire_token_for_client(scopes=SCOPES)
+            if "access_token" not in result:
+                raise RuntimeError(result.get("error_description", "Failed to acquire Graph token"))
+            return result["access_token"]
+
+        return await asyncio.to_thread(acquire)
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        token = await self._acquire_token()
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.request(
+                method,
+                url,
+                params=params,
+                json=json,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            resp.raise_for_status()
+            return resp.json() if resp.content else {}
+
+    async def get(self, url: str, *, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        return await self.request("GET", url, params=params)
+
+    async def post(self, url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await self.request("POST", url, json=payload)
+
+    async def patch(self, url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await self.request("PATCH", url, json=payload)
+
+    async def list(self, url: str, *, params: Optional[Dict[str, Any]] = None) -> list[Dict[str, Any]]:
+        results: list[Dict[str, Any]] = []
+        next_url: Optional[str] = url
+        next_params = params or {}
+        while next_url:
+            page = await self.get(next_url, params=next_params)
+            results.extend(page.get("value", []))
+            next_url = page.get("@odata.nextLink")
+            next_params = None
+        return results
+```
+
+**app/platforms/registry.py**
+```python
+from typing import Dict
+
+from app.platforms.base import PlatformAdapter
+
+
+REGISTRY: Dict[str, PlatformAdapter] = {}
+
+
+def register_adapter(adapter: PlatformAdapter) -> None:
+    REGISTRY[adapter.platform] = adapter
+
+
+def get_adapter(platform: str) -> PlatformAdapter:
+    try:
+        return REGISTRY[platform]
+    except KeyError as exc:
+        raise ValueError(f"unknown platform {platform}") from exc
+
+
+# Import side-effects register adapters
+from app.platforms import slack  # noqa: E402,F401
+from app.platforms import teams  # noqa: E402,F401
+from app.platforms import outlook  # noqa: E402,F401
+```
+
+**app/platforms/slack/__init__.py**
+```python
+from app.platforms.slack.adapter import adapter
+from app.platforms.registry import register_adapter
+
+register_adapter(adapter)
+```
+
+**app/platforms/slack/adapter.py**
+```python
+from typing import Dict
+
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 from fastapi import APIRouter, Request, Response
+
 from app.config import settings
-from app.workers.tasks import enqueue_condense
-from app.slack.publisher import post_ephemeral_processing
+from app.platforms.base import PlatformAdapter, ThreadContext
+from app.platforms.slack.publisher import SlackPublisher
+from app.workers.tasks import trigger_condense
 
-bolt = AsyncApp(token=settings.SLACK_BOT_TOKEN, signing_secret=settings.SLACK_SIGNING_SECRET)
-handler = AsyncSlackRequestHandler(bolt)
 
-router = APIRouter()
+class SlackAdapter(PlatformAdapter):
+    platform = "slack"
 
-@bolt.command("/condense")
-async def cmd_condense(ack, body, client, respond, logger):
-    await ack()
-    channel_id = body.get("channel_id")
-    trigger_ts = body.get("trigger_id")  # not used
-    thread_ts = body.get("thread_ts") or body.get("message_ts") or body.get("container", {}).get("thread_ts")
-    # Fallback: current message context
-    if not thread_ts:
-        thread_ts = body.get("message_ts")
-    user_id = body.get("user_id")
-    team_id = body.get("team_id")
-    await post_ephemeral_processing(client, channel_id, user_id)
-    await enqueue_condense(team_id=team_id, channel_id=channel_id, thread_ts=thread_ts, requester_user_id=user_id)
+    def __init__(self) -> None:
+        self.app = AsyncApp(token=settings.SLACK_BOT_TOKEN, signing_secret=settings.SLACK_SIGNING_SECRET)
+        self.handler = AsyncSlackRequestHandler(self.app)
+        self.router = APIRouter()
+        self.publisher = SlackPublisher(self.app.client)
+        self._register_routes()
 
-@bolt.event("reaction_added")
-async def on_reaction_added(event, logger):
-    # Optional: store for agreement signals. Enqueue lightweight update.
-    pass
+    def serialize_thread_ref(self, context: ThreadContext) -> Dict[str, Any]:
+        team_id = context.metadata.get("team_id") or context.workspace_id
+        return {
+            "platform": self.platform,
+            "team_id": team_id,
+            "channel_id": context.channel_id,
+            "thread_ts": context.thread_id,
+        }
 
-@bolt.event("message")
-async def on_message(event, logger):
-    # No-op; ingestion happens on demand and during watch window.
-    pass
+    def context_from_thread_ref(self, thread_ref: Dict[str, Any], requester_id: str | None) -> ThreadContext:
+        team_id = thread_ref.get("team_id", "")
+        channel_id = thread_ref.get("channel_id", "")
+        thread_ts = thread_ref.get("thread_ts", "")
+        return ThreadContext(
+            platform=self.platform,
+            workspace_id=team_id,
+            channel_id=channel_id,
+            thread_id=thread_ts,
+            requester_id=requester_id,
+            metadata={"team_id": team_id},
+        )
 
-@bolt.action("item_confirm")
-async def on_item_confirm(ack, body, client, logger):
-    await ack()
-    # body contains action + state; send to worker
-    from app.workers.tasks import enqueue_item_confirm
-    await enqueue_item_confirm(body)
+    async def acknowledge(self, context: ThreadContext) -> None:
+        # Bolt handles immediate ack via decorator; nothing extra here.
+        return None
 
-@bolt.action("item_edit")
-async def on_item_edit(ack, body, client, logger):
-    await ack()
-    from app.workers.tasks import enqueue_item_edit
-    await enqueue_item_edit(body)
+    async def send_processing_notice(self, context: ThreadContext) -> None:
+        await self.publisher.post_ephemeral_processing(context.channel_id, context.requester_id or "")
 
-@router.post("/slack/events")
-async def slack_events(req: Request):
-    return await handler.handle(req)
+    async def publish_brief(self, context: ThreadContext, brief: CondenseResult) -> None:
+        await self.publisher.publish_brief(context.channel_id, context.thread_id, brief)
+
+    def _register_routes(self) -> None:
+        bolt = self.app
+
+        @bolt.command("/condense")
+        async def cmd_condense(ack, body, logger):
+            await ack()
+            channel_id = body.get("channel_id")
+            thread_ts = body.get("thread_ts") or body.get("message_ts") or body.get("container", {}).get("thread_ts")
+            if not thread_ts:
+                thread_ts = body.get("message_ts")
+            user_id = body.get("user_id")
+            team_id = body.get("team_id")
+            context = ThreadContext(
+                platform=self.platform,
+                workspace_id=team_id,
+                channel_id=channel_id,
+                thread_id=thread_ts,
+                requester_id=user_id,
+                metadata={"team_id": team_id},
+            )
+            thread_ref = self.serialize_thread_ref(context)
+            trigger_condense(context.platform, thread_ref, context.requester_id)
+            await self.send_processing_notice(context)
+
+        @self.router.post("/slack/events")
+        async def slack_events(request: Request) -> Response:
+            return await self.handler.handle(request)
+
+
+adapter = SlackAdapter()
+router = adapter.router
 ```
-
-**app/slack/blocks.py**
+**app/platforms/slack/blocks.py**
 ```python
 def item_section(item, idx: int):
     title = item.get("title") or item.get("task") or item.get("statement") or item.get("question")
@@ -663,12 +979,21 @@ def item_section(item, idx: int):
     owner = item.get("owner") or "Unassigned"
     due = item.get("due_date") or "-"
     quotes = item.get("supporting_msgs", [])[:2]
-    quote_text = "\n".join([f"> {q['quote']}" for q in quotes])
+    quote_lines = []
+    for ref in quotes:
+        line = ref.get("quote", "")
+        if ref.get("url"):
+            line = f"<{ref['url']}|{line}>"
+        quote_lines.append(f"> {line}")
+    quote_text = "\n".join(quote_lines)
     return [
         {"type": "section", "text": {"type": "mrkdwn", "text": f"*{title}*\nOwner: `{owner}`  Due: `{due}`  Conf: *{confidence}%*\n{quote_text}"}},
         {"type": "actions", "elements": [
             {"type": "button", "text": {"type": "plain_text", "text": "Confirm"}, "style": "primary", "action_id": "item_confirm", "value": str(idx)},
-            {"type": "button", "text": {"type": "plain_text", "text": "Edit"}, "action_id": "item_edit", "value": str(idx)}
+            {"type": "button", "text": {"type": "plain_text", "text": "Edit"}, "action_id": "item_edit", "value": str(idx)},
+            {"type": "button", "text": {"type": "plain_text", "text": "Assign"}, "action_id": "item_assign", "value": str(idx)},
+            {"type": "button", "text": {"type": "plain_text", "text": "Create ticket"}, "action_id": "item_create_ticket", "value": str(idx)},
+            {"type": "button", "text": {"type": "plain_text", "text": "Snooze"}, "action_id": "item_snooze", "value": str(idx)}
         ]},
         {"type": "divider"}
     ]
@@ -692,22 +1017,425 @@ def brief_card(result_json: dict):
     return blocks
 ```
 
-**app/slack/publisher.py**
+**app/platforms/slack/publisher.py**
 ```python
 from slack_sdk.web.async_client import AsyncWebClient
-from app.slack.blocks import brief_card
+from app.schemas import CondenseResult
+from app.platforms.slack.blocks import brief_card
 
-async def post_ephemeral_processing(client: AsyncWebClient, channel_id: str, user_id: str):
-    await client.chat_postEphemeral(channel=channel_id, user=user_id, text="Processing thread…")
 
-async def post_brief_card(client: AsyncWebClient, channel_id: str, thread_ts: str, brief_json: dict, pin: bool = False):
-    blocks = brief_card(brief_json)
-    resp = await client.chat_postMessage(channel=channel_id, thread_ts=thread_ts, text="Condensed brief", blocks=blocks)
-    if pin:
-        try:
-            await client.pins_add(channel=channel_id, timestamp=resp["ts"])
-        except Exception:
-            pass
+class SlackPublisher:
+    def __init__(self, client: AsyncWebClient):
+        self.client = client
+
+    async def post_ephemeral_processing(self, channel_id: str, user_id: str) -> None:
+        if not user_id:
+            return
+        await self.client.chat_postEphemeral(channel=channel_id, user=user_id, text="Processing thread…")
+
+    async def publish_brief(self, channel_id: str, thread_ts: str, brief: CondenseResult, pin: bool = False) -> None:
+        payload = brief.model_dump(mode="json")
+        blocks = brief_card(payload)
+        resp = await self.client.chat_postMessage(channel=channel_id, thread_ts=thread_ts, text="Condensed brief", blocks=blocks)
+        if pin:
+            try:
+                await self.client.pins_add(channel=channel_id, timestamp=resp["ts"])
+            except Exception:
+                pass
+```
+
+**app/platforms/teams/__init__.py**
+```python
+from app.platforms.teams.bot import adapter
+from app.platforms.registry import register_adapter
+
+register_adapter(adapter)
+```
+
+**app/platforms/teams/cards.py**
+```python
+from typing import List
+
+from app.schemas import CondenseResult
+
+
+def _section(title: str, items: List[dict]) -> dict:
+    facts = []
+    for item in items:
+        summary = item.get("summary") or item.get("task") or item.get("statement") or item.get("question")
+        owner = item.get("owner") or "Unassigned"
+        due = item.get("due_date") or "-"
+        confidence = int(round(item.get("confidence", 0.0) * 100))
+        facts.append({
+            "title": summary,
+            "value": f"Owner: {owner}  Due: {due}  Confidence: {confidence}%",
+        })
+    return {
+        "type": "FactSet",
+        "title": title,
+        "facts": facts,
+    }
+
+
+def build_adaptive_card(brief: CondenseResult) -> dict:
+    body = [
+        {"type": "TextBlock", "text": "Thread Condenser", "weight": "bolder", "size": "medium"}
+    ]
+    sections = [
+        ("Decisions", brief.decisions),
+        ("Risks", brief.risks),
+        ("Actions", brief.actions),
+        ("Open questions", brief.open_questions),
+    ]
+    for title, items in sections:
+        if not items:
+            continue
+        body.append({"type": "TextBlock", "text": f"{title} ({len(items)})", "weight": "bolder", "spacing": "medium"})
+        body.append(_section(title, [i.model_dump(mode="json") for i in items]))
+
+    return {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": body,
+    }
+```
+
+**app/platforms/teams/publisher.py**
+```python
+from typing import Dict
+
+from app.platforms.graph_client import GraphClient
+from app.schemas import CondenseResult
+from app.platforms.teams.cards import build_adaptive_card
+
+
+class TeamsPublisher:
+    def __init__(self) -> None:
+        self.graph = GraphClient()
+
+    async def post_processing(self, metadata: Dict[str, str]) -> None:
+        message_id = metadata["message_id"]
+        url = self._reply_url(metadata, message_id)
+        payload = {
+            "body": {"contentType": "html", "content": "Condensing thread…"},
+        }
+        await self.graph.post(url, payload)
+
+    async def publish_brief(self, metadata: Dict[str, str], brief: CondenseResult) -> None:
+        message_id = metadata["message_id"]
+        url = self._reply_url(metadata, message_id)
+        card = build_adaptive_card(brief)
+        payload = {
+            "body": {"contentType": "html", "content": "Thread Condenser summary"},
+            "attachments": [
+                {
+                    "id": "1",
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": card,
+                }
+            ],
+        }
+        await self.graph.post(url, payload)
+
+    def _reply_url(self, metadata: Dict[str, str], message_id: str) -> str:
+        if metadata.get("conversation_type") == "chat":
+            chat_id = metadata["chat_id"]
+            return f"https://graph.microsoft.com/v1.0/chats/{chat_id}/messages/{message_id}/replies"
+        team_id = metadata["team_id"]
+        channel_id = metadata["channel_id"]
+        return f"https://graph.microsoft.com/v1.0/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies"
+```
+
+**app/platforms/teams/bot.py**
+```python
+from typing import Dict
+
+from fastapi import APIRouter, Request
+from botbuilder.schema import Activity
+from botframework.connector.auth import JwtTokenValidation, SimpleCredentialProvider
+
+from app.config import settings
+from app.platforms.base import PlatformAdapter, ThreadContext
+from app.platforms.teams.publisher import TeamsPublisher
+from app.schemas import CondenseResult
+from app.workers.tasks import trigger_condense
+
+
+class TeamsAdapter(PlatformAdapter):
+    platform = "msteams"
+
+    def __init__(self) -> None:
+        self.router = APIRouter()
+        self.publisher = TeamsPublisher()
+        self.credentials = SimpleCredentialProvider(settings.TEAMS_BOT_APP_ID, settings.TEAMS_BOT_APP_PASSWORD)
+        self._register_routes()
+
+    def serialize_thread_ref(self, context: ThreadContext) -> Dict[str, str]:
+        metadata = context.metadata.copy()
+        tenant_id = metadata.get("tenant_id") or context.workspace_id
+        return {
+            "platform": self.platform,
+            "tenant_id": tenant_id,
+            "team_id": metadata.get("team_id", ""),
+            "channel_id": metadata.get("channel_id", ""),
+            "chat_id": metadata.get("chat_id", ""),
+            "conversation_type": metadata.get("conversation_type", "chat" if metadata.get("chat_id") else "channel"),
+            "message_id": context.thread_id,
+        }
+
+    def context_from_thread_ref(self, thread_ref: Dict[str, Any], requester_id: str | None) -> ThreadContext:
+        tenant_id = thread_ref.get("tenant_id", "")
+        conversation_type = thread_ref.get("conversation_type", "channel")
+        channel_id = thread_ref.get("channel_id") or thread_ref.get("chat_id") or ""
+        metadata = {
+            "tenant_id": tenant_id,
+            "team_id": thread_ref.get("team_id", ""),
+            "channel_id": thread_ref.get("channel_id", ""),
+            "chat_id": thread_ref.get("chat_id", ""),
+            "conversation_type": conversation_type,
+        }
+        return ThreadContext(
+            platform=self.platform,
+            workspace_id=tenant_id or thread_ref.get("team_id", ""),
+            channel_id=channel_id,
+            thread_id=thread_ref.get("message_id", ""),
+            requester_id=requester_id,
+            metadata=metadata,
+        )
+
+    async def acknowledge(self, context: ThreadContext) -> None:
+        return None
+
+    async def send_processing_notice(self, context: ThreadContext) -> None:
+        await self.publisher.post_processing(context.metadata)
+
+    async def publish_brief(self, context: ThreadContext, brief: CondenseResult) -> None:
+        await self.publisher.publish_brief(context.metadata, brief)
+
+    def _register_routes(self) -> None:
+        @self.router.post("/teams/messages")
+        async def teams_messages(request: Request):
+            body = await request.json()
+            activity = Activity().deserialize(body)
+            auth_header = request.headers.get("Authorization", "")
+            await JwtTokenValidation.authenticate_request(activity, auth_header, self.credentials, channel_service=None)
+            context = self._context_from_activity(activity)
+            thread_ref = self.serialize_thread_ref(context)
+            trigger_condense(context.platform, thread_ref, context.requester_id)
+            await self.send_processing_notice(context)
+            return {"status": 200, "body": {"type": "message", "text": "Condensing thread…"}}
+
+    def _context_from_activity(self, activity: Activity) -> ThreadContext:
+        channel_data = activity.channel_data or {}
+        value = activity.value or {}
+        message_payload = value.get("messagePayload") or {}
+        team = channel_data.get("team") or {}
+        channel = channel_data.get("channel") or {}
+        tenant = channel_data.get("tenant") or {}
+
+        team_id = team.get("id")
+        channel_id = channel.get("id") or (activity.conversation.id if channel else None)
+        conversation_type = "chat" if not channel_id or channel_id.startswith("19:") else "channel"
+        chat_id = activity.conversation.id if conversation_type == "chat" else None
+        message_id = message_payload.get("id") or activity.reply_to_id or activity.conversation.id
+        requester_id = activity.from_property.id if activity.from_property else None
+        tenant_id = (activity.conversation.tenant_id if activity.conversation else None) or tenant.get("id")
+
+        metadata = {
+            "team_id": team_id or "",
+            "channel_id": channel_id or chat_id or "",
+            "chat_id": chat_id or "",
+            "tenant_id": tenant_id or "",
+            "conversation_type": conversation_type,
+        }
+
+        return ThreadContext(
+            platform=self.platform,
+            workspace_id=tenant_id or team_id or "",
+            channel_id=channel_id or chat_id or "",
+            thread_id=message_id,
+            requester_id=requester_id,
+            metadata=metadata,
+        )
+
+
+adapter = TeamsAdapter()
+router = adapter.router
+```
+
+**app/platforms/outlook/__init__.py**
+```python
+from app.platforms.outlook.graph import adapter
+from app.platforms.registry import register_adapter
+
+register_adapter(adapter)
+```
+
+**app/platforms/outlook/actionable.py**
+```python
+from app.schemas import CondenseResult
+
+
+def build_actionable_card(brief: CondenseResult) -> dict:
+    body = [
+        {"type": "TextBlock", "text": "Thread Condenser", "weight": "bolder", "size": "medium"}
+    ]
+    for title, items in (
+        ("Decisions", brief.decisions),
+        ("Risks", brief.risks),
+        ("Actions", brief.actions),
+        ("Open questions", brief.open_questions),
+    ):
+        if not items:
+            continue
+        body.append({"type": "TextBlock", "text": f"{title} ({len(items)})", "weight": "bolder", "spacing": "medium"})
+        for item in items:
+            summary = item.summary if hasattr(item, "summary") else getattr(item, "task", "")
+            owner = getattr(item, "owner", None) or "Unassigned"
+            confidence = int(round(getattr(item, "confidence", 0.0) * 100))
+            body.append({
+                "type": "TextBlock",
+                "text": f"{summary}\nOwner: {owner} • Confidence: {confidence}%",
+                "wrap": True,
+            })
+
+    return {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": body,
+    }
+```
+
+**app/platforms/outlook/publisher.py**
+```python
+from typing import Dict
+
+from app.platforms.graph_client import GraphClient
+from app.platforms.outlook.actionable import build_actionable_card
+from app.schemas import CondenseResult
+
+
+class OutlookPublisher:
+    def __init__(self) -> None:
+        self.graph = GraphClient()
+
+    async def post_processing(self, metadata: Dict[str, str]) -> None:
+        mailbox = metadata["mailbox"]
+        message_id = metadata["message_id"]
+        url = f"https://graph.microsoft.com/v1.0/users/{mailbox}/messages/{message_id}/reply"
+        await self.graph.post(url, {"comment": "Condensing thread…"})
+
+    async def publish_brief(self, metadata: Dict[str, str], brief: CondenseResult) -> None:
+        mailbox = metadata["mailbox"]
+        message_id = metadata["message_id"]
+        base = f"https://graph.microsoft.com/v1.0/users/{mailbox}/messages/{message_id}"
+        draft = await self.graph.post(f"{base}/createReply", {})
+        draft_id = draft["id"]
+        card = build_actionable_card(brief)
+        payload = {
+            "body": {
+                "contentType": "html",
+                "content": "Thread Condenser summary",
+            },
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": card,
+                    "name": "summary.json",
+                }
+            ],
+        }
+        await self.graph.patch(f"https://graph.microsoft.com/v1.0/users/{mailbox}/messages/{draft_id}", payload)
+        await self.graph.post(f"https://graph.microsoft.com/v1.0/users/{mailbox}/messages/{draft_id}/send", {})
+```
+
+**app/platforms/outlook/graph.py**
+```python
+from typing import Dict
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.platforms.base import PlatformAdapter, ThreadContext
+from app.platforms.outlook.publisher import OutlookPublisher
+from app.schemas import CondenseResult
+from app.workers.tasks import trigger_condense
+
+
+class OutlookAdapter(PlatformAdapter):
+    platform = "outlook"
+
+    def __init__(self) -> None:
+        self.router = APIRouter()
+        self.publisher = OutlookPublisher()
+        self._register_routes()
+
+    def serialize_thread_ref(self, context: ThreadContext) -> Dict[str, str]:
+        ref = {
+            "platform": self.platform,
+            "mailbox": context.channel_id,
+            "conversation_id": context.thread_id,
+        }
+        ref.update(context.metadata)
+        return ref
+
+    def context_from_thread_ref(self, thread_ref: Dict[str, Any], requester_id: str | None) -> ThreadContext:
+        mailbox = thread_ref.get("mailbox", "")
+        conversation_id = thread_ref.get("conversation_id", "")
+        tenant_id = thread_ref.get("tenant_id", "")
+        metadata = thread_ref.copy()
+        return ThreadContext(
+            platform=self.platform,
+            workspace_id=tenant_id or mailbox,
+            channel_id=mailbox,
+            thread_id=conversation_id,
+            requester_id=requester_id,
+            metadata=metadata,
+        )
+
+    async def acknowledge(self, context: ThreadContext) -> None:
+        return None
+
+    async def send_processing_notice(self, context: ThreadContext) -> None:
+        await self.publisher.post_processing(context.metadata)
+
+    async def publish_brief(self, context: ThreadContext, brief: CondenseResult) -> None:
+        await self.publisher.publish_brief(context.metadata, brief)
+
+    def _register_routes(self) -> None:
+        @self.router.post("/outlook/actions")
+        async def outlook_actions(request: Request):
+            payload = await request.json()
+            try:
+                mailbox = payload["mailbox"]
+                message_id = payload["messageId"]
+                conversation_id = payload["conversationId"]
+                tenant_id = payload.get("tenantId", "")
+            except KeyError as exc:
+                raise HTTPException(status_code=400, detail=f"missing field {exc.args[0]}") from exc
+
+            context = ThreadContext(
+                platform=self.platform,
+                workspace_id=tenant_id,
+                channel_id=mailbox,
+                thread_id=conversation_id,
+                requester_id=payload.get("requester"),
+                metadata={
+                    "mailbox": mailbox,
+                    "message_id": message_id,
+                    "conversation_id": conversation_id,
+                    "tenant_id": tenant_id,
+                },
+            )
+            thread_ref = self.serialize_thread_ref(context)
+            trigger_condense(context.platform, thread_ref, context.requester_id)
+            await self.send_processing_notice(context)
+            return {"status": "queued"}
+
+
+adapter = OutlookAdapter()
+router = adapter.router
 ```
 
 ---
@@ -716,26 +1444,34 @@ async def post_brief_card(client: AsyncWebClient, channel_id: str, thread_ts: st
 
 **app/api/v1.py**
 ```python
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
-from app.auth import verify_jwt
-from app.deps import get_db
 from sqlalchemy.orm import Session
+
+from app.deps import get_db
 from app.models import Brief
-import orjson
 
 router = APIRouter(prefix="/v1")
 
+
 class CondenseRequest(BaseModel):
-    thread_url: str
+    platform: str
+    thread_ref: dict
     options: dict | None = None
+
+
+class GraphNotification(BaseModel):
+    value: list[dict] = []
+    validationToken: str | None = None
+
 
 @router.post("/condense")
 def condense(req: CondenseRequest, db: Session = Depends(get_db)):
-    # For external calls (non-Slack). Enqueue job similarly.
     from app.workers.tasks import enqueue_condense_external
-    run_id = enqueue_condense_external(req.thread_url, req.options or {})
+
+    run_id = enqueue_condense_external(req.platform, req.thread_ref, req.options or {})
     return {"run_id": run_id}
+
 
 @router.get("/briefs/{run_id}")
 def get_brief(run_id: str, db: Session = Depends(get_db)):
@@ -744,26 +1480,59 @@ def get_brief(run_id: str, db: Session = Depends(get_db)):
         raise HTTPException(404)
     return brief.json_blob
 
+
 class EditRequest(BaseModel):
     patch: dict
+
 
 @router.post("/items/{item_id}/edit")
 def edit_item(item_id: str, req: EditRequest, db: Session = Depends(get_db)):
     from app.workers.tasks import edit_item_sync
+
     return edit_item_sync(item_id, req.patch, db)
+
+
+@router.get("/graph/notifications")
+def graph_validation(validationToken: str):
+    return Response(content=validationToken, media_type="text/plain")
+
+
+@router.post("/graph/notifications")
+def graph_notifications(payload: GraphNotification):
+    from app.workers.tasks import trigger_condense
+
+    if payload.validationToken:
+        return Response(content=payload.validationToken, media_type="text/plain")
+    for notification in payload.value:
+        resource = notification.get("resource", "")
+        resource_data = notification.get("resourceData", {})
+        if "/messages" not in resource:
+            continue
+        if "/chats/" in resource or "/teams/" in resource:
+            platform = "msteams"
+        else:
+            platform = "outlook"
+        thread_ref = {**resource_data, "resource": resource}
+        trigger_condense(platform, thread_ref, None)
+    return {"status": "accepted"}
 ```
 
 **app/main.py**
 ```python
 from fastapi import FastAPI
+
 from app.logging import setup_logging
-from app.slack.bolt_app import router as slack_router
+from app.platforms.slack.adapter import router as slack_router
+from app.platforms.teams.bot import router as teams_router
+from app.platforms.outlook.graph import router as outlook_router
 from app.api.v1 import router as api_router
 
 setup_logging()
 app = FastAPI(title="Thread Condenser")
 
 app.include_router(slack_router)
+app.include_router(teams_router)
+app.include_router(outlook_router)
 app.include_router(api_router)
 ```
 
@@ -857,7 +1626,7 @@ You summarize a chat segment into 1–5 bullets with message-level anchors.
 Rules:
 - Only summarize content present in the segment.
 - Use neutral, factual language.
-- After each bullet, include [ts=<slack_ts>] for at least one supporting message.
+- After each bullet, include `[ref=<platform>:<native_id>]` for at least one supporting message.
 
 Return plain text bullets.
 ```
@@ -878,9 +1647,11 @@ Output strictly this JSON object:
 
 Constraints:
 - Extract a Decision only with explicit commitment/approval verbs.
-- Every item must include at least one supporting message with exact short quote and message ts.
+- Every supporting message must include `{ "platform": "...", "native_id": "...", "msg_id": "<platform>:<native_id>", "quote": "..." }` and the quote must be <=280 characters.
 - Use ISO 8601 UTC for due_date when present, else null.
 - Confidence in [0,1]. Do not fabricate owners or dates.
+- Populate `people_map` with display name → `{platform, native_id, email?}` for every mention you resolve.
+- `provenance.message_ids` shall contain the canonical `msg_id` values for all supporting messages.
 ```
 
 ---
@@ -889,75 +1660,508 @@ Constraints:
 
 **app/pipeline/ingest.py**
 ```python
+from __future__ import annotations
+
+import html
+import re
+from datetime import datetime, timezone
+from hashlib import sha1
+from typing import Any, Dict, List, Optional
+
 from slack_sdk.web.async_client import AsyncWebClient
 from sqlalchemy.orm import Session
-from app.models import Thread, Message, User, Channel, Workspace
-from hashlib import sha1
 
-async def ingest_thread(db: Session, client: AsyncWebClient, team_id: str, channel_id: str, thread_ts: str, url: str):
-    # Ensure workspace and channel exist
-    ws = db.query(Workspace).filter_by(slack_team_id=team_id).first()
+from app.models import Channel, Message, Thread, User, Workspace
+from app.platforms.graph_client import GraphClient
+
+UTC = timezone.utc
+BR_RE = re.compile(r"<br\s*/?>|</p>", re.I)
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _html_to_text(value: str) -> str:
+    if not value:
+        return ""
+    text = BR_RE.sub("\n", value)
+    text = TAG_RE.sub("", text)
+    return html.unescape(text).strip()
+
+
+def _parse_dt(value: Optional[str]) -> datetime:
+    if not value:
+        return datetime.now(tz=UTC)
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _ensure_workspace(db: Session, platform: str, workspace_key: str) -> Workspace:
+    if platform == "slack":
+        lookup = {"slack_team_id": workspace_key}
+    else:
+        lookup = {"m365_tenant_id": workspace_key}
+    ws = db.query(Workspace).filter_by(**lookup).first()
     if not ws:
-        ws = Workspace(tenant_id=None, slack_team_id=team_id)  # tenant_id set by admin in real deployments
-        db.add(ws); db.commit()
-    ch = db.query(Channel).filter_by(workspace_id=ws.id, slack_channel_id=channel_id).first()
-    if not ch:
-        ch = Channel(workspace_id=ws.id, slack_channel_id=channel_id)
-        db.add(ch); db.commit()
-    th = db.query(Thread).filter_by(workspace_id=ws.id, slack_thread_ts=thread_ts).first()
-    if not th:
-        th = Thread(workspace_id=ws.id, channel_id=ch.id, slack_thread_ts=thread_ts, url=url)
-        db.add(th); db.commit()
+        ws = Workspace(
+            tenant_id=None,
+            slack_team_id=workspace_key if platform == "slack" else None,
+            m365_tenant_id=workspace_key if platform != "slack" else None,
+        )
+        db.add(ws)
+        db.commit()
+    return ws
 
-    # Fetch thread replies
-    messages = []
-    cursor = None
+
+def _ensure_channel(
+    db: Session,
+    workspace: Workspace,
+    platform: str,
+    external_id: str,
+    *,
+    parent_resource_id: Optional[str] = None,
+    display_name: Optional[str] = None,
+    mailbox: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Channel:
+    ch = (
+        db.query(Channel)
+        .filter_by(workspace_id=workspace.id, platform=platform, external_id=external_id)
+        .first()
+    )
+    if not ch:
+        ch = Channel(
+            workspace_id=workspace.id,
+            platform=platform,
+            external_id=external_id,
+            parent_resource_id=parent_resource_id,
+            display_name=display_name,
+            mailbox_address=mailbox,
+            metadata=metadata or {},
+        )
+        db.add(ch)
+    else:
+        if parent_resource_id:
+            ch.parent_resource_id = parent_resource_id
+        if display_name and not ch.display_name:
+            ch.display_name = display_name
+        if mailbox:
+            ch.mailbox_address = mailbox
+        if metadata:
+            merged = ch.metadata or {}
+            merged.update(metadata)
+            ch.metadata = merged
+    db.commit()
+    return ch
+
+
+def _ensure_user(
+    db: Session,
+    workspace: Workspace,
+    platform: str,
+    native_id: Optional[str],
+    display_name: Optional[str],
+    *,
+    email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[User]:
+    if not native_id:
+        return None
+    user = (
+        db.query(User)
+        .filter_by(workspace_id=workspace.id, platform=platform, platform_user_id=native_id)
+        .first()
+    )
+    if not user:
+        user = User(
+            workspace_id=workspace.id,
+            platform=platform,
+            platform_user_id=native_id,
+            display_name=display_name or native_id,
+            email=email,
+            metadata=metadata or {},
+        )
+        db.add(user)
+        db.commit()
+        return user
+    updated = False
+    if display_name and user.display_name != display_name:
+        user.display_name = display_name
+        updated = True
+    if email and user.email != email:
+        user.email = email
+        updated = True
+    if metadata:
+        merged = user.metadata or {}
+        merged.update(metadata)
+        user.metadata = merged
+        updated = True
+    if updated:
+        db.commit()
+    return user
+
+
+def _ensure_thread(
+    db: Session,
+    workspace: Workspace,
+    channel: Channel,
+    platform: str,
+    source_thread_id: str,
+    *,
+    parent_resource_id: Optional[str],
+    thread_url: str,
+) -> Thread:
+    th = (
+        db.query(Thread)
+        .filter_by(workspace_id=workspace.id, platform=platform, source_thread_id=source_thread_id)
+        .first()
+    )
+    if not th:
+        th = Thread(
+            workspace_id=workspace.id,
+            channel_id=channel.id,
+            platform=platform,
+            source_thread_id=source_thread_id,
+            source_parent_id=parent_resource_id,
+            source_url=thread_url,
+        )
+        db.add(th)
+    else:
+        if thread_url and th.source_url != thread_url:
+            th.source_url = thread_url
+        if parent_resource_id and th.source_parent_id != parent_resource_id:
+            th.source_parent_id = parent_resource_id
+    db.commit()
+    return th
+
+
+def _persist_message(
+    db: Session,
+    thread: Thread,
+    platform: str,
+    native_id: str,
+    *,
+    parent_id: Optional[str],
+    user: Optional[User],
+    text: str,
+    created_at: datetime,
+    reactions: Optional[Dict[str, int]],
+    metadata: Dict[str, Any],
+) -> None:
+    canonical = f"{platform}:{native_id}"
+    metadata = metadata or {}
+    metadata.setdefault("canonical_id", canonical)
+    msg = (
+        db.query(Message)
+        .filter_by(thread_id=thread.id, source_msg_id=native_id)
+        .first()
+    )
+    text_hash = sha1(text.encode("utf-8")).hexdigest()
+    if msg:
+        msg.text = text
+        msg.text_hash = text_hash
+        msg.parent_msg_id = parent_id
+        msg.author_user_id = user.id if user else None
+        msg.reactions_json = reactions or {}
+        msg.metadata_json = metadata
+        msg.created_at = created_at
+    else:
+        db.add(
+            Message(
+                thread_id=thread.id,
+                platform=platform,
+                source_msg_id=native_id,
+                parent_msg_id=parent_id,
+                author_user_id=user.id if user else None,
+                text=text,
+                text_hash=text_hash,
+                reactions_json=reactions or {},
+                metadata_json=metadata,
+                created_at=created_at,
+            )
+        )
+
+
+async def _ingest_slack(db: Session, slack_client: AsyncWebClient, thread_ref: Dict[str, Any]) -> Thread:
+    team_id = thread_ref["team_id"]
+    channel_id = thread_ref["channel_id"]
+    thread_ts = thread_ref["thread_ts"]
+    workspace = _ensure_workspace(db, "slack", team_id)
+    channel = _ensure_channel(
+        db,
+        workspace,
+        "slack",
+        channel_id,
+        parent_resource_id=team_id,
+        metadata={"team_id": team_id},
+    )
+    thread_url = f"https://app.slack.com/client/{team_id}/{channel_id}/{thread_ts.replace('.', 'p')}"
+    thread = _ensure_thread(
+        db,
+        workspace,
+        channel,
+        "slack",
+        thread_ts,
+        parent_resource_id=channel_id,
+        thread_url=thread_url,
+    )
+    messages: List[Dict[str, Any]] = []
+    cursor: Optional[str] = None
     while True:
-        resp = await client.conversations_replies(channel=channel_id, ts=thread_ts, cursor=cursor, limit=200)
+        resp = await slack_client.conversations_replies(channel=channel_id, ts=thread_ts, cursor=cursor, limit=200)
         messages.extend(resp.get("messages", []))
         cursor = resp.get("response_metadata", {}).get("next_cursor")
         if not cursor:
             break
 
-    for m in messages:
-        user_id = m.get("user")
-        u = None
+    user_cache: Dict[str, User] = {}
+    for payload in messages:
+        user_id = payload.get("user") or payload.get("bot_id")
+        user: Optional[User] = None
         if user_id:
-            u = db.query(User).filter_by(workspace_id=ws.id, slack_user_id=user_id).first()
-            if not u:
-                # fetch profile minimally
-                try:
-                    profile = (await client.users_info(user=user_id))["user"]["profile"]
-                    display_name = profile.get("display_name") or profile.get("real_name") or user_id
-                except Exception:
-                    display_name = user_id
-                u = User(workspace_id=ws.id, slack_user_id=user_id, display_name=display_name)
-                db.add(u); db.commit()
-        text = m.get("text") or ""
-        mh = sha1(text.encode("utf-8")).hexdigest()
-        exists = db.query(Message).filter_by(thread_id=th.id, slack_ts=m["ts"]).first()
-        if not exists:
-            db.add(Message(thread_id=th.id, slack_ts=m["ts"], author_user_id=u.id if u else None, text=text, text_hash=mh, reactions_json=m.get("reactions", [])))
+            user = user_cache.get(user_id)
+            if not user:
+                display_name = user_id
+                email = None
+                if user_id.startswith("U"):
+                    try:
+                        info = await slack_client.users_info(user=user_id)
+                        profile = info["user"]["profile"]
+                        display_name = profile.get("display_name") or profile.get("real_name") or user_id
+                        email = profile.get("email")
+                    except Exception:
+                        display_name = user_id
+                user = _ensure_user(db, workspace, "slack", user_id, display_name, email=email)
+                user_cache[user_id] = user
+        ts = payload["ts"]
+        created_at = datetime.fromtimestamp(float(ts), tz=UTC)
+        parent_ts = payload.get("thread_ts")
+        parent_id = parent_ts if parent_ts and parent_ts != ts else None
+        reactions = {r["name"]: r.get("count", 0) for r in payload.get("reactions", [])}
+        metadata = {
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "permalink": f"https://app.slack.com/client/{team_id}/{channel_id}/{ts.replace('.', 'p')}",
+            "thread_ts": payload.get("thread_ts"),
+        }
+        _persist_message(
+            db,
+            thread,
+            "slack",
+            ts,
+            parent_id=parent_id,
+            user=user,
+            text=payload.get("text") or "",
+            created_at=created_at,
+            reactions=reactions,
+            metadata=metadata,
+        )
     db.commit()
-    return th
+    return thread
+
+
+async def _ingest_teams(db: Session, graph_client: GraphClient, thread_ref: Dict[str, Any]) -> Thread:
+    tenant_id = thread_ref.get("tenant_id") or ""
+    workspace_key = tenant_id or thread_ref.get("team_id") or thread_ref.get("chat_id") or ""
+    workspace = _ensure_workspace(db, "msteams", workspace_key)
+    conversation_type = thread_ref.get("conversation_type", "channel")
+    if conversation_type == "chat":
+        chat_id = thread_ref["chat_id"]
+        base = f"https://graph.microsoft.com/v1.0/chats/{chat_id}/messages"
+        external_id = chat_id
+        parent_resource = chat_id
+        channel_metadata = {"conversation_type": "chat"}
+    else:
+        team_id = thread_ref["team_id"]
+        channel_id = thread_ref["channel_id"]
+        base = f"https://graph.microsoft.com/v1.0/teams/{team_id}/channels/{channel_id}/messages"
+        external_id = channel_id
+        parent_resource = team_id
+        channel_metadata = {"team_id": team_id, "conversation_type": "channel"}
+    channel = _ensure_channel(
+        db,
+        workspace,
+        "msteams",
+        external_id,
+        parent_resource_id=parent_resource,
+        metadata=channel_metadata,
+    )
+    message_id = thread_ref["message_id"]
+    root = await graph_client.get(f"{base}/{message_id}")
+    replies = await graph_client.list(f"{base}/{message_id}/replies")
+    payloads = [root] + replies
+    thread_url = root.get("webUrl", "")
+    thread = _ensure_thread(
+        db,
+        workspace,
+        channel,
+        "msteams",
+        message_id,
+        parent_resource_id=external_id,
+        thread_url=thread_url,
+    )
+    for payload in payloads:
+        from_part = payload.get("from", {})
+        user_info = from_part.get("user") or {}
+        native_user_id = user_info.get("id") or from_part.get("application", {}).get("id")
+        display_name = user_info.get("displayName") or from_part.get("application", {}).get("displayName") or native_user_id
+        email = user_info.get("email") or user_info.get("userPrincipalName")
+        user = _ensure_user(db, workspace, "msteams", native_user_id, display_name, email=email)
+        body = payload.get("body", {}).get("content", "")
+        text = _html_to_text(body)
+        created_at = _parse_dt(payload.get("createdDateTime"))
+        reactions: Dict[str, int] = {}
+        for reaction in payload.get("reactions", []):
+            key = reaction.get("reactionType", "other")
+            reactions[key] = reactions.get(key, 0) + 1
+        metadata = {
+            "webUrl": payload.get("webUrl"),
+            "raw_html": body,
+            "createdDateTime": payload.get("createdDateTime"),
+            "lastModifiedDateTime": payload.get("lastModifiedDateTime"),
+        }
+        parent_id = payload.get("replyToId")
+        if not parent_id and payload.get("id") != message_id:
+            parent_id = message_id
+        _persist_message(
+            db,
+            thread,
+            "msteams",
+            payload["id"],
+            parent_id=parent_id,
+            user=user,
+            text=text,
+            created_at=created_at,
+            reactions=reactions,
+            metadata=metadata,
+        )
+    db.commit()
+    return thread
+
+
+async def _ingest_outlook(db: Session, graph_client: GraphClient, thread_ref: Dict[str, Any]) -> Thread:
+    mailbox = thread_ref["mailbox"]
+    conversation_id = thread_ref["conversation_id"]
+    tenant_id = thread_ref.get("tenant_id") or ""
+    workspace_key = tenant_id or mailbox
+    workspace = _ensure_workspace(db, "outlook", workspace_key)
+    channel = _ensure_channel(
+        db,
+        workspace,
+        "outlook",
+        mailbox,
+        parent_resource_id=tenant_id or mailbox,
+        mailbox=mailbox,
+    )
+    params = {
+        "$filter": f"conversationId eq '{conversation_id}'",
+        "$orderby": "createdDateTime asc",
+    }
+    payloads = await graph_client.list(
+        f"https://graph.microsoft.com/v1.0/users/{mailbox}/messages",
+        params=params,
+    )
+    thread_url = payloads[0].get("webLink", "") if payloads else ""
+    thread = _ensure_thread(
+        db,
+        workspace,
+        channel,
+        "outlook",
+        conversation_id,
+        parent_resource_id=mailbox,
+        thread_url=thread_url,
+    )
+    previous_id: Optional[str] = None
+    for payload in payloads:
+        sender = payload.get("from", {}).get("emailAddress", {})
+        native_user_id = sender.get("address") or sender.get("name")
+        display_name = sender.get("name") or native_user_id
+        email = sender.get("address")
+        user = _ensure_user(db, workspace, "outlook", native_user_id, display_name, email=email)
+        body = payload.get("body", {}).get("content", "")
+        text = _html_to_text(body)
+        created_at = _parse_dt(payload.get("sentDateTime") or payload.get("receivedDateTime"))
+        metadata = {
+            "webLink": payload.get("webLink"),
+            "internetMessageId": payload.get("internetMessageId"),
+            "conversationIndex": payload.get("conversationIndex"),
+            "toRecipients": payload.get("toRecipients", []),
+            "ccRecipients": payload.get("ccRecipients", []),
+            "raw_html": body,
+        }
+        parent_id = payload.get("replyToId") or payload.get("inReplyTo") or previous_id
+        native_id = payload["id"]
+        _persist_message(
+            db,
+            thread,
+            "outlook",
+            native_id,
+            parent_id=parent_id,
+            user=user,
+            text=text,
+            created_at=created_at,
+            reactions={},
+            metadata=metadata,
+        )
+        previous_id = native_id
+    db.commit()
+    return thread
+
+
+async def ingest_thread(
+    db: Session,
+    platform: str,
+    thread_ref: Dict[str, Any],
+    *,
+    slack_client: Optional[AsyncWebClient] = None,
+    graph_client: Optional[GraphClient] = None,
+) -> Thread:
+    if platform == "slack":
+        if not slack_client:
+            raise RuntimeError("Slack client is required for Slack ingestion")
+        return await _ingest_slack(db, slack_client, thread_ref)
+    if platform == "msteams":
+        if not graph_client:
+            raise RuntimeError("Graph client is required for Microsoft Teams ingestion")
+        return await _ingest_teams(db, graph_client, thread_ref)
+    if platform == "outlook":
+        if not graph_client:
+            raise RuntimeError("Graph client is required for Outlook ingestion")
+        return await _ingest_outlook(db, graph_client, thread_ref)
+    raise ValueError(f"Unsupported platform {platform}")
 ```
 
 **app/pipeline/preprocess.py**
 ```python
+from __future__ import annotations
+
 import re
 from sqlalchemy.orm import Session
+
 from app.models import Message
 
 CODE_RE = re.compile(r"```.*?```", re.S)
 
-def clean_text(text: str) -> str:
-    # Preserve code blocks, strip Slack formatting noise
-    return text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&").strip()
 
-def preprocess_thread(db: Session, thread_id):
-    msgs = db.query(Message).filter(Message.thread_id==thread_id).order_by(Message.slack_ts).all()
-    for m in msgs:
-        m.text = clean_text(m.text)
+def _normalize_text(message: Message) -> str:
+    text = message.text or ""
+    text = text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+    if message.platform in {"msteams", "outlook"}:
+        text = text.replace("\r", "")
+    return text.strip()
+
+
+def preprocess_thread(db: Session, thread_id: str) -> list[Message]:
+    msgs = (
+        db.query(Message)
+        .filter(Message.thread_id == thread_id)
+        .order_by(Message.created_at.asc())
+        .all()
+    )
+    for msg in msgs:
+        msg.text = _normalize_text(msg)
+        metadata = msg.metadata_json or {}
+        canonical = metadata.get("canonical_id") or f"{msg.platform}:{msg.source_msg_id}"
+        metadata["canonical_id"] = canonical
+        metadata["source_msg_id"] = msg.source_msg_id
+        msg.metadata_json = metadata
     db.commit()
     return msgs
 ```
@@ -966,35 +2170,54 @@ def preprocess_thread(db: Session, thread_id):
 ```python
 from app.llm.tokenization import count_tokens
 
-def segment_messages(messages, max_tokens=2000, model="gpt-4o-mini"):
-    segments = []
-    buf = []
+
+def segment_messages(messages, max_tokens: int = 2000, model: str = "gpt-4o-mini") -> list[str]:
+    segments: list[str] = []
+    buf: list[str] = []
     tokens = 0
-    for m in messages:
-        t = f"[{m.slack_ts}] {m.text}\n"
-        c = count_tokens(t, model=model)
-        if tokens + c > max_tokens and buf:
-            segments.append(buf); buf=[t]; tokens=c
+    for message in messages:
+        metadata = message.metadata_json or {}
+        canonical = metadata.get("canonical_id") or f"{message.platform}:{message.source_msg_id}"
+        line = f"[{canonical}] {message.text}\n"
+        count = count_tokens(line, model=model)
+        if tokens + count > max_tokens and buf:
+            segments.append("".join(buf))
+            buf = [line]
+            tokens = count
         else:
-            buf.append(t); tokens += c
+            buf.append(line)
+            tokens += count
     if buf:
-        segments.append(buf)
-    return ["".join(s) for s in segments]
+        segments.append("".join(buf))
+    return segments
 ```
 
 **app/pipeline/owner_infer.py**
 ```python
 import re
+from typing import Optional
 
-MENTION = re.compile(r"<@([A-Z0-9]+)>")
-def infer_owner(text: str, last_speaker_slack_id: str | None = None) -> str | None:
-    # Imperative @mention
-    m = MENTION.search(text)
-    if m and re.search(r"\b(please|can you|do|fix|take|own|handle)\b", text.lower()):
-        return m.group(1)
-    # Self-assign
-    if re.search(r"\bI(\'ll| will| can)\b", text):
-        return last_speaker_slack_id
+MENTION = re.compile(r"@([A-Za-z0-9._-]+)")
+SELF_ASSIGN = re.compile(r"\bI(?:'m| will| can| shall)?\b", re.I)
+IMPERATIVE = re.compile(r"\b(please|can you|could you|take|own|handle|drive)\b", re.I)
+
+
+def infer_owner(
+    text: str,
+    mention_map: dict[str, str] | None = None,
+    last_speaker: Optional[str] = None,
+) -> Optional[str]:
+    lowered = text.lower()
+    tokens = mention_map or {}
+    for token, canonical in tokens.items():
+        if token in text and IMPERATIVE.search(lowered):
+            return canonical
+    match = MENTION.search(text)
+    if match and IMPERATIVE.search(lowered):
+        candidate = match.group(1)
+        return tokens.get(candidate, candidate)
+    if SELF_ASSIGN.search(text) and last_speaker:
+        return last_speaker
     return None
 ```
 
@@ -1012,74 +2235,157 @@ def normalize_date(phrase: str, tz_name: str | None = "UTC") -> str | None:
 
 **app/pipeline/extract.py**
 ```python
-from app.llm.router import get_llm
-from app.config import settings
-from app.schemas import CondenseResult
 import json
+from typing import Any, Dict
 
-async def extract_items(thread_url: str, segments: list[str], run_id: str):
+from app.config import settings
+from app.llm.router import get_llm
+from app.schemas import CondenseResult
+
+
+async def extract_items(
+    platform: str,
+    thread_url: str,
+    thread_ref: Dict[str, Any],
+    segments: list[str],
+    run_id: str,
+) -> CondenseResult:
     llm = get_llm()
-    system = open("app/prompts/extraction.md","r",encoding="utf-8").read()
-    # Merge segments; if too long, send separately and merge
+    system = open("app/prompts/extraction.md", "r", encoding="utf-8").read()
     merged = "\n\n".join(segments)
-    if len(merged) > 200000:  # guard
-        merged = merged[:200000]
-    user = f"Thread URL: {thread_url}\nContent:\n{merged}"
-    schema_hint = json.dumps(CondenseResult.model_json_schema(), separators=(",",":"))
-    res = await llm.complete_json(system=system, user=user, model=settings.OPENAI_MODEL, temperature=0.2, max_tokens=2000, schema_hint=schema_hint)
-    # Ensure required keys
-    for k in ["decisions","risks","actions","open_questions","people_map","provenance"]:
-        res.setdefault(k, [] if k not in ["people_map","provenance"] else ({} if k=="people_map" else {}))
-    res["provenance"]["run_id"] = run_id
-    res["provenance"]["thread_url"] = thread_url
-    return res
+    if len(merged) > 200_000:
+        merged = merged[:200_000]
+    user = f"Source platform: {platform}\nThread URL: {thread_url}\nContent:\n{merged}"
+    schema_hint = json.dumps(CondenseResult.model_json_schema(), separators=(",", ":"))
+    raw = await llm.complete_json(
+        system=system,
+        user=user,
+        model=settings.OPENAI_MODEL,
+        temperature=0.2,
+        max_tokens=2000,
+        schema_hint=schema_hint,
+    )
+    raw.setdefault("decisions", [])
+    raw.setdefault("risks", [])
+    raw.setdefault("actions", [])
+    raw.setdefault("open_questions", [])
+    raw.setdefault("people_map", {})
+    provenance = raw.setdefault("provenance", {})
+    provenance.setdefault("message_ids", [])
+    provenance["thread_url"] = thread_url
+    provenance["run_id"] = run_id
+    provenance["source_platform"] = platform
+    provenance["source_thread_ref"] = thread_ref
+    raw["platform"] = platform
+    result = CondenseResult.model_validate(raw)
+    for section in [result.decisions, result.risks, result.actions, result.open_questions]:
+        for item in section:
+            for ref in item.supporting_msgs:
+                if not ref.platform:
+                    ref.platform = platform
+                if not ref.msg_id:
+                    ref.msg_id = f"{ref.platform}:{ref.native_id}"
+    message_ids = {
+        ref.msg_id
+        for section in [result.decisions, result.risks, result.actions, result.open_questions]
+        for item in section
+        for ref in item.supporting_msgs
+        if ref.msg_id
+    }
+    result.provenance.message_ids = sorted(message_ids)
+    return result
 ```
 
 **app/pipeline/rank.py**
 ```python
-def score_item(item: dict, reactions_index: dict[str,int], seniority_weight: float = 1.0, recency_bonus: float = 0.0, contradiction_penalty: float = 0.0):
-    base = float(item.get("confidence", 0.0))
-    msg_ids = [r["msg_id"] for r in item.get("supporting_msgs", []) if "msg_id" in r]
-    agree = sum(reactions_index.get(m, 0) for m in msg_ids)
-    s = base + 0.05 * agree + 0.05 * seniority_weight + recency_bonus - contradiction_penalty
-    return max(0.0, min(1.0, s))
+from app.schemas import CondenseResult
 
-def rank_and_filter(result_json: dict, threshold: float):
-    reactions_index = {}
-    for sec in ["decisions","risks","actions","open_questions"]:
-        ranked=[]
-        for it in result_json.get(sec, []):
-            s = score_item(it, reactions_index)
-            it["confidence"] = s
-            if s >= threshold:
-                ranked.append(it)
-        result_json[sec] = sorted(ranked, key=lambda x: x["confidence"], reverse=True)
-    return result_json
+
+def score_item(
+    item,
+    reactions_index: dict[str, int],
+    seniority_weight: float = 1.0,
+    recency_bonus: float = 0.0,
+    contradiction_penalty: float = 0.0,
+) -> float:
+    base = float(getattr(item, "confidence", 0.0))
+    agree = sum(reactions_index.get(ref.msg_id, 0) for ref in item.supporting_msgs)
+    score = base + 0.05 * agree + 0.05 * seniority_weight + recency_bonus - contradiction_penalty
+    return max(0.0, min(1.0, score))
+
+
+def rank_and_filter(result: CondenseResult, reactions_index: dict[str, int], threshold: float) -> CondenseResult:
+    for attr in ["decisions", "risks", "actions", "open_questions"]:
+        filtered = []
+        for item in getattr(result, attr):
+            score = score_item(item, reactions_index)
+            item.confidence = score
+            if score >= threshold:
+                filtered.append(item)
+        filtered.sort(key=lambda it: it.confidence, reverse=True)
+        setattr(result, attr, filtered)
+    return result
 ```
 
 **app/pipeline/provenance.py**
 ```python
-def attach_links(workspace_team_id: str, channel_id: str, items: list[dict]):
-    base = f"https://app.slack.com/client/{workspace_team_id}/{channel_id}/"
-    for it in items:
-        for s in it.get("supporting_msgs", []):
-            ts = s.get("msg_id")
-            if ts:
-                s["url"] = base + ts.replace(".", "p")
-    return items
+from typing import Iterable
+
+from app.models import Message
+from app.schemas import CondenseResult
+
+
+def attach_links(messages: Iterable[Message], brief: CondenseResult) -> CondenseResult:
+    index = {}
+    for msg in messages:
+        metadata = msg.metadata_json or {}
+        canonical = metadata.get("canonical_id") or f"{msg.platform}:{msg.source_msg_id}"
+        index[canonical] = msg
+
+    for section in [brief.decisions, brief.risks, brief.actions, brief.open_questions]:
+        for item in section:
+            for ref in item.supporting_msgs:
+                canonical = ref.msg_id or f"{ref.platform}:{ref.native_id}"
+                msg = index.get(canonical)
+                if not msg:
+                    continue
+                metadata = msg.metadata_json or {}
+                ref.platform = msg.platform
+                ref.native_id = msg.source_msg_id
+                ref.msg_id = metadata.get("canonical_id", canonical)
+                ref.url = metadata.get("permalink") or metadata.get("webUrl") or metadata.get("webLink")
+    return brief
 ```
 
 **app/pipeline/brief.py**
 ```python
 from sqlalchemy.orm import Session
-from app.models import Brief
-from datetime import datetime
 
-def save_brief(db: Session, run_id: str, thread_id, json_blob: dict, model_version="v1.0", api_version="v1"):
-    b = Brief(run_id=run_id, thread_id=thread_id, version="1", model_version=model_version, api_version=api_version, json_blob=json_blob)
-    db.merge(b)
+from app.models import Brief
+from app.schemas import CondenseResult
+
+
+def save_brief(
+    db: Session,
+    run_id: str,
+    thread_id,
+    brief: CondenseResult,
+    model_version: str = "v1.0",
+    api_version: str = "v1",
+):
+    payload = brief.model_dump(mode="json")
+    record = Brief(
+        run_id=run_id,
+        thread_id=thread_id,
+        platform=brief.platform,
+        version="1",
+        model_version=model_version,
+        api_version=api_version,
+        json_blob=payload,
+    )
+    db.merge(record)
     db.commit()
-    return b
+    return record
 ```
 
 **app/pipeline/summarization.py** *(optional, for segment-level bullets)*
@@ -1119,56 +2425,118 @@ celery_app.conf.result_expires = 3600
 
 **app/workers/tasks.py**
 ```python
-import asyncio, uuid
+import asyncio
+import uuid
+from typing import Any, Dict
+
 from celery import shared_task
-from app.db import SessionLocal
-from app.config import settings
 from slack_sdk.web.async_client import AsyncWebClient
+
+from app.config import settings
+from app.db import SessionLocal
+from app.platforms.graph_client import GraphClient
+from app.platforms.registry import get_adapter
+from app.pipeline.brief import save_brief
+from app.pipeline.extract import extract_items
 from app.pipeline.ingest import ingest_thread
 from app.pipeline.preprocess import preprocess_thread
-from app.pipeline.segment import segment_messages
-from app.pipeline.extract import extract_items
-from app.pipeline.rank import rank_and_filter
 from app.pipeline.provenance import attach_links
-from app.pipeline.brief import save_brief
-from app.slack.publisher import post_brief_card
+from app.pipeline.rank import rank_and_filter
+from app.pipeline.segment import segment_messages
+
+
+_graph_client: GraphClient | None = None
+
+
+def _get_graph_client() -> GraphClient:
+    global _graph_client
+    if _graph_client is None:
+        _graph_client = GraphClient()
+    return _graph_client
+
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
 
-async def _enqueue_condense(team_id: str, channel_id: str, thread_ts: str, requester_user_id: str | None):
-    run_id = f"rc-{uuid.uuid4()}"
-    client = AsyncWebClient(token=settings.SLACK_BOT_TOKEN)
+
+def _build_reaction_index(messages) -> dict[str, int]:
+    index: dict[str, int] = {}
+    for msg in messages:
+        metadata = msg.metadata_json or {}
+        canonical = metadata.get("canonical_id")
+        if not canonical:
+            continue
+        reactions = msg.reactions_json or {}
+        if isinstance(reactions, dict):
+            index[canonical] = sum(int(v) for v in reactions.values())
+        elif isinstance(reactions, list):
+            index[canonical] = sum(int(r.get("count", 0)) for r in reactions)
+    return index
+
+
+async def _process_condense(
+    platform: str,
+    thread_ref: Dict[str, Any],
+    requester_user_id: str | None,
+    options: Dict[str, Any],
+) -> str:
+    run_id = options.get("run_id") or f"rc-{uuid.uuid4()}"
+    slack_client: AsyncWebClient | None = None
     db = SessionLocal()
     try:
-        url = f"https://app.slack.com/client/{team_id}/{channel_id}/{thread_ts.replace('.','p')}"
-        th = await ingest_thread(db, client, team_id, channel_id, thread_ts, url)
-        msgs = preprocess_thread(db, th.id)
-        segments = segment_messages(msgs, max_tokens=2000, model=settings.OPENAI_MODEL)
-        result = await extract_items(url, segments, run_id)
-        # Optional link enrichment
-        for sec in ["decisions","risks","actions","open_questions"]:
-            result[sec] = attach_links(team_id, channel_id, result.get(sec, []))
-        ranked = rank_and_filter(result, settings.PROMOTION_THRESHOLD)
-        save_brief(db, run_id, th.id, ranked)
-        # Post card and pin
-        await post_brief_card(client, channel_id, thread_ts, ranked, pin=True)
+        graph = _get_graph_client() if platform in {"msteams", "outlook"} else None
+        if platform == "slack":
+            slack_client = AsyncWebClient(token=settings.SLACK_BOT_TOKEN)
+        thread = await ingest_thread(
+            db,
+            platform,
+            thread_ref,
+            slack_client=slack_client,
+            graph_client=graph,
+        )
+        messages = preprocess_thread(db, thread.id)
+        segments = segment_messages(messages, max_tokens=2000, model=settings.OPENAI_MODEL)
+        brief = await extract_items(platform, thread.source_url, thread_ref, segments, run_id)
+        reactions_index = _build_reaction_index(messages)
+        ranked = rank_and_filter(brief, reactions_index, settings.PROMOTION_THRESHOLD)
+        ranked = attach_links(messages, ranked)
+        save_brief(db, run_id, thread.id, ranked)
+        adapter = get_adapter(platform)
+        context = adapter.context_from_thread_ref(thread_ref, requester_user_id)
+        await adapter.publish_brief(context, ranked)
     finally:
-        await client.close()
+        if slack_client is not None:
+            await slack_client.close()
         db.close()
     return run_id
 
-@shared_task(name="enqueue_condense_task", queue="webhooks")
-def enqueue_condense(team_id: str, channel_id: str, thread_ts: str, requester_user_id: str | None = None):
-    return _run(_enqueue_condense(team_id, channel_id, thread_ts, requester_user_id))
 
-def enqueue_condense_external(thread_url: str, options: dict):
-    # Parse URL: .../client/{team}/{channel}/{pTS}
-    from urllib.parse import urlparse
-    parts = urlparse(thread_url).path.split("/")
-    team_id, channel_id, p_ts = parts[-3], parts[-2], parts[-1]
-    thread_ts = p_ts.replace("p", "", 1)
-    return enqueue_condense(team_id, channel_id, thread_ts, None)
+@shared_task(name="enqueue_condense_task", queue="webhooks")
+def enqueue_condense(
+    platform: str,
+    thread_ref: Dict[str, Any],
+    requester_user_id: str | None = None,
+    options: Dict[str, Any] | None = None,
+):
+    return _run(_process_condense(platform, thread_ref, requester_user_id, options or {}))
+
+
+def trigger_condense(
+    platform: str,
+    thread_ref: Dict[str, Any],
+    requester_user_id: str | None = None,
+    options: Dict[str, Any] | None = None,
+) -> str:
+    run_id = f"rc-{uuid.uuid4()}"
+    payload = options.copy() if options else {}
+    payload["run_id"] = run_id
+    enqueue_condense.delay(platform, thread_ref, requester_user_id, payload)
+    return run_id
+
+
+def enqueue_condense_external(platform: str, thread_ref: Dict[str, Any], options: Dict[str, Any]):
+    return trigger_condense(platform, thread_ref, None, options)
 
 @shared_task(name="enqueue_item_confirm", queue="webhooks")
 def enqueue_item_confirm(payload: dict):
@@ -1273,10 +2641,14 @@ Add minimal tests.
 **tests/test_segment.py**
 ```python
 from app.pipeline.segment import segment_messages
-class Msg: 
-    def __init__(self, ts, text): self.slack_ts=ts; self.text=text
+class Msg:
+    def __init__(self, platform, msg_id, text):
+        self.platform = platform
+        self.source_msg_id = msg_id
+        self.text = text
+        self.metadata_json = {"canonical_id": f"{platform}:{msg_id}"}
 def test_segment_small():
-    msgs=[Msg("1","hello"), Msg("2","world")]
+    msgs=[Msg("slack","1","hello"), Msg("slack","2","world")]
     segs = segment_messages(msgs, max_tokens=1000, model="gpt-4o-mini")
     assert len(segs)==1 and "hello" in segs[0]
 ```
@@ -1373,6 +2745,6 @@ Celery logs emit task lifecycle. Add structured logs via `app.logging.setup_logg
 
 ## 22) End-to-end flow recap
 
-- `/condense` → Celery enqueues → ingest Slack thread → preprocess → segment → LLM extract (JSON) → attach links → rank/filter → save brief → post Block Kit card and pin.
+- `/condense` → Celery enqueues → ingest Slack/Teams/Outlook thread via platform adapter → preprocess → segment → LLM extract (JSON) → attach links → rank/filter → save brief → publish Adaptive Card / Block Kit / actionable mail.
 
 This document includes all required code and steps to run locally, develop features, and deploy.


### PR DESCRIPTION
## Summary
- expand requirements to cover Microsoft Teams and Outlook ingestion, canonical message IDs, and Microsoft Graph notification endpoints
- refresh the architecture narrative for multi-platform adapters, Graph subscriptions, and cross-platform publishing
- rewrite implementation plan to introduce shared Graph client, platform-aware ingestion pipeline, and asynchronous Celery trigger helpers

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cee3a59ed483218aed93ba8eb1656f