### PR TITLE
Ensure Teams metadata carries message id

### DIFF
--- a/app/platforms/teams/bot.py
+++ b/app/platforms/teams/bot.py
@@ -49,18 +49,20 @@ class TeamsAdapter(PlatformAdapter):
         tenant_id = thread_ref.get("tenant_id", "")
         conversation_type = thread_ref.get("conversation_type", "channel")
         channel_id = thread_ref.get("channel_id") or thread_ref.get("chat_id") or ""
+        message_id = thread_ref.get("message_id", "")
         metadata = {
             "tenant_id": tenant_id,
             "team_id": thread_ref.get("team_id", ""),
             "channel_id": thread_ref.get("channel_id", ""),
             "chat_id": thread_ref.get("chat_id", ""),
             "conversation_type": conversation_type,
+            "message_id": message_id,
         }
         return ThreadContext(
             platform=self.platform,
             workspace_id=tenant_id or thread_ref.get("team_id", ""),
             channel_id=channel_id,
-            thread_id=thread_ref.get("message_id", ""),
+            thread_id=message_id,
             requester_id=requester_id,
             metadata=metadata,
         )
@@ -126,6 +128,7 @@ class TeamsAdapter(PlatformAdapter):
             "chat_id": chat_id or "",
             "tenant_id": tenant_id or "",
             "conversation_type": conversation_type,
+            "message_id": message_id or "",
         }
 
         return ThreadContext(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_teams_bot.py
+++ b/tests/test_teams_bot.py
@@ -1,0 +1,155 @@
+import asyncio
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+
+os.environ.setdefault("APP_SECRET", "test-secret")
+os.environ.setdefault("POSTGRES_DSN", "sqlite:///test.db")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test")
+os.environ.setdefault("SLACK_SIGNING_SECRET", "signing-secret")
+
+
+if "botframework.connector.auth" not in sys.modules:
+    botframework_module = types.ModuleType("botframework")
+    connector_module = types.ModuleType("botframework.connector")
+    auth_module = types.ModuleType("botframework.connector.auth")
+
+    class SimpleCredentialProvider:
+        def __init__(self, app_id, app_password):
+            self.app_id = app_id
+            self.app_password = app_password
+
+    class JwtTokenValidation:
+        @staticmethod
+        async def authenticate_request(*args, **kwargs):
+            return None
+
+    auth_module.SimpleCredentialProvider = SimpleCredentialProvider
+    auth_module.JwtTokenValidation = JwtTokenValidation
+    connector_module.auth = auth_module
+    botframework_module.connector = connector_module
+
+    sys.modules.setdefault("botframework", botframework_module)
+    sys.modules.setdefault("botframework.connector", connector_module)
+    sys.modules.setdefault("botframework.connector.auth", auth_module)
+
+if "app.platforms.registry" not in sys.modules:
+    fake_registry = types.ModuleType("app.platforms.registry")
+    fake_registry.REGISTRY = {}
+
+    def _register_adapter(adapter):  # pragma: no cover - test stub
+        fake_registry.REGISTRY[adapter.platform] = adapter
+
+    def _get_adapter(platform):  # pragma: no cover - test stub
+        return fake_registry.REGISTRY[platform]
+
+    fake_registry.register_adapter = _register_adapter
+    fake_registry.get_adapter = _get_adapter
+    sys.modules.setdefault("app.platforms.registry", fake_registry)
+
+if "app.workers.tasks" not in sys.modules:
+    fake_tasks = types.ModuleType("app.workers.tasks")
+
+    def _fake_trigger_condense(*args, **kwargs):  # pragma: no cover - test stub
+        return None
+
+    fake_tasks.trigger_condense = _fake_trigger_condense
+    sys.modules.setdefault("app.workers.tasks", fake_tasks)
+
+from app.platforms.teams.bot import TeamsAdapter
+
+
+class DummyPublisher:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def post_processing(self, metadata):
+        self.calls.append(("post_processing", metadata.copy()))
+
+    async def publish_brief(self, metadata, brief):
+        self.calls.append(("publish_brief", metadata.copy(), brief))
+
+
+ACTIVITY_MESSAGE_ID = "activity-message-id"
+THREAD_MESSAGE_ID = "thread-message-id"
+
+
+def _build_activity_context(adapter: TeamsAdapter):
+    activity = SimpleNamespace(
+        channel_data={
+            "team": {"id": "team-123"},
+            "channel": {"id": "channel-456"},
+            "tenant": {"id": "tenant-789"},
+        },
+        value={"messagePayload": {"id": ACTIVITY_MESSAGE_ID}},
+        conversation=SimpleNamespace(id="conversation-xyz", tenant_id="tenant-789"),
+        reply_to_id=None,
+        from_property=SimpleNamespace(id="user-123"),
+    )
+    context = adapter._context_from_activity(activity)
+    return context, ACTIVITY_MESSAGE_ID
+
+
+def _build_thread_ref_context(adapter: TeamsAdapter):
+    thread_ref = {
+        "tenant_id": "tenant-789",
+        "team_id": "team-123",
+        "channel_id": "channel-456",
+        "chat_id": "",
+        "conversation_type": "channel",
+        "message_id": THREAD_MESSAGE_ID,
+    }
+    context = adapter.context_from_thread_ref(thread_ref, requester_id="user-123")
+    return context, THREAD_MESSAGE_ID
+
+
+def test_teams_adapter_round_trips_message_id():
+    adapter = TeamsAdapter()
+    thread_ref = {
+        "tenant_id": "tenant-789",
+        "team_id": "team-123",
+        "channel_id": "channel-456",
+        "chat_id": "",
+        "conversation_type": "channel",
+        "message_id": THREAD_MESSAGE_ID,
+    }
+
+    context = adapter.context_from_thread_ref(thread_ref, requester_id="user-123")
+
+    assert context.thread_id == THREAD_MESSAGE_ID
+    assert context.metadata["message_id"] == THREAD_MESSAGE_ID
+
+    serialized = adapter.serialize_thread_ref(context)
+
+    assert serialized["message_id"] == THREAD_MESSAGE_ID
+
+
+def test_send_processing_notice_and_publish_brief_include_message_id():
+    adapter = TeamsAdapter()
+    adapter.publisher = DummyPublisher()
+
+    for context_factory, expected in (
+        (_build_activity_context, ACTIVITY_MESSAGE_ID),
+        (_build_thread_ref_context, THREAD_MESSAGE_ID),
+    ):
+        adapter.publisher.calls.clear()
+        context, message_id = context_factory(adapter)
+
+        assert message_id == expected
+        assert context.metadata["message_id"] == expected
+
+        asyncio.run(adapter.send_processing_notice(context))
+
+        brief = object()
+        asyncio.run(adapter.publish_brief(context, brief))
+
+        assert len(adapter.publisher.calls) == 2
+        assert adapter.publisher.calls[-2][0] == "post_processing"
+        assert adapter.publisher.calls[-2][1]["message_id"] == expected
+        assert adapter.publisher.calls[-1][0] == "publish_brief"
+        assert adapter.publisher.calls[-1][1]["message_id"] == expected
+        assert adapter.publisher.calls[-1][2] is brief
+


### PR DESCRIPTION
## Summary
- ensure Teams thread contexts carry the active message id in their metadata
- add tests covering Teams adapter serialization and publisher calls with stubbed dependencies
- configure test imports to find the application package during pytest runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16622f5348321ae4b8d73d6570d22