### PR TITLE
Handle missing tiktoken import fallback

### DIFF
--- a/app/llm/tokenization.py
+++ b/app/llm/tokenization.py
@@ -1,10 +1,15 @@
-import tiktoken
-
-
 def count_tokens(text: str, model: str = "gpt-4o-mini") -> int:
     try:
-        enc = tiktoken.encoding_for_model(model)
-        return len(enc.encode(text))
-    except Exception:  # pragma: no cover - fallback path
-        # Network access may be blocked during tests; fall back to a simple heuristic.
-        return max(1, len(text) // 4 + 1)
+        import tiktoken  # type: ignore
+    except ImportError:  # pragma: no cover - fallback path
+        tiktoken = None
+
+    if tiktoken is not None:
+        try:
+            enc = tiktoken.encoding_for_model(model)
+            return len(enc.encode(text))
+        except Exception:  # pragma: no cover - fallback path
+            pass
+
+    # Network access may be blocked during tests; fall back to a simple heuristic.
+    return max(1, len(text) // 4 + 1)

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,19 @@
+import sys
+
+from app.llm.tokenization import count_tokens
+
+
+def test_count_tokens_without_tiktoken():
+    original_module = sys.modules.pop("tiktoken", None)
+    sys.modules["tiktoken"] = None
+
+    try:
+        result = count_tokens("Hello world")
+    finally:
+        if original_module is not None:
+            sys.modules["tiktoken"] = original_module
+        else:
+            sys.modules.pop("tiktoken", None)
+
+    assert isinstance(result, int)
+    assert result > 0


### PR DESCRIPTION
## Summary
- load `tiktoken` lazily inside `count_tokens` and fall back to the heuristic when the import fails
- add a regression test that removes `tiktoken` from `sys.modules` to ensure `count_tokens` still returns a value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d169209770832181656cf85852f1c4